### PR TITLE
Mocking HTTP requests in tests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ name = "pypi"
 
 praw = "*"
 requests = "*"
+requests-mock = "*"
 
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "619c94ac74a3cc62a26a134a314b7ca684084673dc977f113e89a75263a590d7"
+            "sha256": "b2520ca9b5043087d2d7e3bf369b370e116dfc5736c5071302fa2a4a180a69f5"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -70,6 +70,20 @@
                 "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
             ],
             "version": "==2.18.4"
+        },
+        "requests-mock": {
+            "hashes": [
+                "sha256:96a1e45b1c0bd18d14fcb2d55b3b09d6d46237e37bcae3155df4cb75bc42619e",
+                "sha256:2931887853c42e1d73879983d5bf03041109472991c5b4b8dba5d11ed23b9d0b"
+            ],
+            "version": "==1.4.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+            ],
+            "version": "==1.11.0"
         },
         "update-checker": {
             "hashes": [

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -1,4 +1,7 @@
 import unittest
+import requests_mock
+
+import json
 from src.search import *
 
 
@@ -10,11 +13,17 @@ class TestSearch(unittest.TestCase):
 
         self.assertEqual(expected_endpoint, compose_endpoint(filters))
 
-    def test_get_medals(self):
+    @requests_mock.Mocker()
+    def test_get_medals(self, mock_requests):
+        # Mocking HTTP requests to avoid making real requests
+        api_url = 'http://www.khuxbot.com/api/v1/medal?q=data&filter=%7B%22rarity%22:%206,%22direction%22:%22Upright%22,%22element%22:%22Power%22,%22cost%22:%224%22,%22tier%22:%226%22%7D'
+        api_response = json.loads(open('test/fixtures/medals_upright_power_c4_t6.json').read())
+        mock_requests.get(api_url, json=api_response)
+
         filters = {"direction": "Upright", "element": "Power", "cost": 4, "tier": 6}
         expected_medals = [
-            { "cost": 4, "defence": 5665, "direction": "Upright", "element": "Power", "hits": 12, "id": 943, "image_link": "/static/medal_images//Kings_Roar_6.png", "multiplier": "x2.10-3.28", "name": "Kings Roar", "notes": "Decreases enemy defense by one step for two turns; increases your power attack by two steps for two turns; deals more damage the further back it's set in your deck", "pullable": "Yes", "rarity": 6, "region": "na", "strength": 5753, "targets": "All", "tier": 6, "type": "Combat" },
-            { "cost": 4, "defence": 5718, "direction": "Upright", "element": "Power", "hits": 11, "id": 982, "image_link": "/static/medal_images//Toon_Sora_6.png", "multiplier": "x1.99-3.35","name": "Toon Sora","notes": "Increases the enemy's count by +1, increases your PSM attack by three steps for two turns, deals more damage the higher your HP","pullable": "No","rarity": 6,"region": "na","strength": 5756,"targets": "All","tier": 6,"type": "Combat" }
+            {"cost": 4, "defence": 5665, "direction": "Upright", "element": "Power", "hits": 12, "id": 943, "image_link": "/static/medal_images//Kings_Roar_6.png", "multiplier": "x2.10-3.28", "name": "Kings Roar", "notes": "Decreases enemy defense by one step for two turns; increases your power attack by two steps for two turns; deals more damage the further back it's set in your deck", "pullable": "Yes", "rarity": 6, "region": "na", "strength": 5753, "targets": "All", "tier": 6, "type": "Combat"},
+            {"cost": 4, "defence": 5718, "direction": "Upright", "element": "Power", "hits": 11, "id": 982, "image_link": "/static/medal_images//Toon_Sora_6.png", "multiplier": "x1.99-3.35","name": "Toon Sora","notes": "Increases the enemy's count by +1, increases your PSM attack by three steps for two turns, deals more damage the higher your HP","pullable": "No","rarity": 6,"region": "na","strength": 5756,"targets": "All","tier": 6,"type": "Combat"}
         ]
 
         self.assertListEqual(expected_medals, get_medals(filters))


### PR DESCRIPTION
## Where?
**Github issue**: #1 

## What?
As the bot relies heavily on the responses from an external API, most of its methods make requests to it in order to get the information they need. We want to mock the HTTP requests we do on tests, in order to avoid making real requests there.

## Why?
Making real HTTP requests during unit testing is not a recommended practice. It greatly slows down the test suite, increases the load on the requested server and introduces an extra level of "possible failure" in our tests (a test may fail because the corresponding HTTP request got lost). We may want to test the HTTP connections to the external API, but not on the same place where we are testing that our methods and classes work as expected.

## How?
After reviewing several possibilities, we've decided to go with the library [requests-mock](https://requests-mock.readthedocs.io/en/latest/). It adapts perfectly to the use of `requests`, and greatly reduces the complexity compared to other possibilities (like `unittest.mock`). 

## Warnings
A con of using `requests-mock` is that in case that we move to another HTTP library in the future we'll have to refactor the testing suite. However, the chances that this happen are very low, and therefore this is undoubtedly the best choice for this use-case. 

Another thing we have to be aware of is that, when indicating the mocked URL, we have to use the URL-encoded format. Specifying it using plain text, even if it's what we'll introduce in the `requests` call, will make the test fail with a `NoMockAddress` exception

_Example_:
If we want to mock `http://www.khuxbot.com/api/v1/medal?q=data&filter={"rarity": 6,"direction":"Upright","element":"Power","cost":"4", "tier":"6"}`
We'll have to mock `http://www.khuxbot.com/api/v1/medal?q=data&filter=%7B%22rarity%22:%206,%22direction%22:%22Upright%22,%22element%22:%22Power%22,%22cost%22:%224%22,%22tier%22:%226%22%7D` 