### PR TITLE
Added PR template and Issue template

### DIFF
--- a/docs/issue_template.md
+++ b/docs/issue_template.md
@@ -1,0 +1,25 @@
+* **I'm submitting a ...**
+  - [ ] bug report
+  - [ ] feature request
+  - [ ] support request => Please do not submit support request here, see note at the top of this template.
+
+
+* **What is the current behavior?**
+
+    * _If the current behavior is a bug, please provide the steps to reproduce it_
+
+
+
+* **What is the expected behavior?**
+
+
+* **Why will this change be beneficial to the project?**
+
+
+* **How do you think this change could be done?**
+    * _This part is not mandatory, but we will be very grateful if you provide us your point of view of which you think that will be the best approach to tackle this_
+
+
+
+
+* **Other information** (e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, gitter, etc)

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,20 @@
+### What?
+_Short descrption of the features that this PR adds or of the bugs that it fixes_
+
+_If there isn't any issue where this change has been requested, specify also why this change is beneficial to the project_
+
+### How
+_Detailed explanation of what changes have you done to accomplish the goal of this PR, what approach have you used and why you decided to use it_
+
+_If you have encountered any problem while developing this code, it may be useful too to reflect it here so everyone can take it into account_
+
+### Where?
+_Specify here the places where this change has been requested_
+
+- **Github issues:** _List here those Github issues related with this PR_
+
+- **Related PRs:** _List here the PRs related with this one_
+
+### Notes and warnings
+_Things that other developers have to take into account related with the changes you've done_
+


### PR DESCRIPTION
### What?
This PR adds templates for _Pull Requests_ and _Issues_. This will be very helpful because it will provide everyone a template with the main points to indicate in each case. 

### How
We've created a new directory, `docs`, and two documents inside it: `pull_request_template.md` and `issue_template.md`

We use this names because this makes Github detect the templates and automatically apply them to all the future Issues and Pull Request of the project. 

### Notes and warnings
In order for Github to use the documents, they have to be on the `master` branch. Therefore, until we merge this PR, the changes won't make any effect


