### PR TITLE
Create Medal and MedalFactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ENV file
+*.env
+
 # Pycharm config files
 .idea/*
 

--- a/src/db.py
+++ b/src/db.py
@@ -1,2 +1,0 @@
-class DBWrapper:
-    pass

--- a/src/models.py
+++ b/src/models.py
@@ -3,10 +3,12 @@ from peewee import *
 db = PostgresqlDatabase(database='database_name', user='postgres',
                         password='secret', host='10.1.0.9', port=5432)
 
+
 class BaseModel(Model):
     """Abstract model that we'll use to make other models inherit DB settings"""
     class Meta:
         database = db
+
 
 class Medal(BaseModel):
     cost = IntegerField()

--- a/src/models.py
+++ b/src/models.py
@@ -9,4 +9,22 @@ class BaseModel(Model):
         database = db
 
 class Medal(BaseModel):
-    pass
+    cost = IntegerField()
+    defence = IntegerField()
+    direction = CharField()
+    hits = IntegerField()
+    id = IntegerField(primary_key=True)
+    image_link = TextField()
+    multiplier_min = FloatField()
+    multiplier_max = FloatField()
+    name = TextField()
+    notes = TextField()
+    pullable = CharField(max_length=3)
+    rarity = IntegerField()
+    region = CharField(max_length=5)
+    strength = IntegerField()
+    targets = CharField(max_length=10)
+    tier = IntegerField()
+    type = CharField(max_length=10)
+    voice_link = TextField()
+

--- a/src/models.py
+++ b/src/models.py
@@ -14,6 +14,7 @@ class Medal(BaseModel):
     cost = IntegerField()
     defence = IntegerField()
     direction = CharField()
+    element = CharField()
     hits = IntegerField()
     id = IntegerField(primary_key=True)
     image_link = TextField()
@@ -31,8 +32,46 @@ class Medal(BaseModel):
     voice_link = TextField()
 
 
-class MedalFactory():
+class MedalFactory:
+
+    @classmethod
+    def parse_multiplier(cls, multiplier_string):
+        return [3.40, 3.40]
 
     @classmethod
     def medal(cls, medal_json):
-        created_medal = Medal
+        created_medal = Medal()
+
+        # We only care about combat medals
+        if not medal_json.get('type', None) == 'Combat':
+            return None
+
+        # Setting the required attributes. If any is empty, we won't create the medal
+        try:
+            created_medal.cost = medal_json['cost']
+            created_medal.direction = medal_json['direction']
+            created_medal.element = medal_json['element']
+            created_medal.hits = medal_json['hits']
+            created_medal.id = medal_json['id']
+            created_medal.multiplier_min, created_medal.multiplier_max = cls.parse_multiplier(medal_json['multiplier'])
+            created_medal.name = medal_json['name']
+            created_medal.rarity = medal_json['rarity']
+            created_medal.targets = medal_json['targets']
+            created_medal.tier = medal_json['tier']
+            created_medal.type = medal_json['type']
+
+        except KeyError:
+            return None
+        
+        created_medal.defence = medal_json.get('defence', None)
+        created_medal.image_link = medal_json.get('image_link', None)
+        created_medal.notes = medal_json.get('notes', None)
+        created_medal.pullable = medal_json.get('pullable', None)
+        created_medal.rarity = medal_json.get('rarity', None)
+        created_medal.region = medal_json.get('region', None)
+        created_medal.strength = medal_json.get('strength', None)
+        created_medal.voice_link = medal_json.get('voice_link', None)
+
+        created_medal.save()
+
+        return created_medal

--- a/src/models.py
+++ b/src/models.py
@@ -29,3 +29,10 @@ class Medal(BaseModel):
     tier = IntegerField()
     type = CharField(max_length=10)
     voice_link = TextField()
+
+
+class MedalFactory():
+
+    @classmethod
+    def medal(cls, medal_json):
+        created_medal = Medal

--- a/src/models.py
+++ b/src/models.py
@@ -7,3 +7,6 @@ class BaseModel(Model):
     """Abstract model that we'll use to make other models inherit DB settings"""
     class Meta:
         database = db
+
+class Medal(BaseModel):
+    pass

--- a/src/models.py
+++ b/src/models.py
@@ -27,4 +27,3 @@ class Medal(BaseModel):
     tier = IntegerField()
     type = CharField(max_length=10)
     voice_link = TextField()
-

--- a/src/models.py
+++ b/src/models.py
@@ -1,7 +1,11 @@
+import os
 from peewee import *
 
-db = PostgresqlDatabase(database='database_name', user='postgres',
-                        password='secret', host='10.1.0.9', port=5432)
+db = PostgresqlDatabase(database=os.environ['DB_DATABASE'],
+                        user=os.environ['DB_USERNAME'],
+                        password=os.environ['DB_PASSWORD'],
+                        host=os.environ['DB_HOST'],
+                        port=os.environ['DB_PORT'])
 
 
 class BaseModel(Model):

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,9 @@
+from peewee import *
+
+db = PostgresqlDatabase(database='database_name', user='postgres',
+                        password='secret', host='10.1.0.9', port=5432)
+
+class BaseModel(Model):
+    """Abstract model that we'll use to make other models inherit DB settings"""
+    class Meta:
+        database = db

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -2,6 +2,7 @@ import requests
 from urllib.parse import urlencode
 
 from src.db import DBWrapper
+from src.models import Medal
 
 
 class Scrapper:
@@ -38,7 +39,7 @@ class Scrapper:
 
     def missing_medals(self):
         """Gets the names of all the medals that aren't yet on the DB"""
-        current_medals = set(DBWrapper.find_all('Medals', ['name']))
+        current_medals = set(medal.name for medal in Medal.select())
         total_medals = set(self.get_medal_names())
 
         return list(total_medals - current_medals)

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -1,7 +1,6 @@
 import requests
 from urllib.parse import urlencode
 
-from src.db import DBWrapper
 from src.models import Medal, MedalFactory
 
 

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -2,7 +2,7 @@ import requests
 from urllib.parse import urlencode
 
 from src.db import DBWrapper
-from src.models import Medal
+from src.models import Medal, MedalFactory
 
 
 class Scrapper:
@@ -33,7 +33,7 @@ class Scrapper:
         medals_dict = response.json()['medal']
         medals = []
         for _, medal in medals_dict.items():
-            medals.append(medal)
+            medals.append(MedalFactory.medal(medal))
 
         return medals
 
@@ -55,11 +55,11 @@ class Scrapper:
                 matching_medals = self.get_medals(medal_name)
 
                 for medal in matching_medals:
-                    if not DBWrapper.is_present('Medals', {"id": medal['id']}):
+                    if not Medal.get_or_none(Medal.id == medal.id):
                         success = (DBWrapper.save('Medals', medal) and success)
 
-        except Exception:
+        except Exception as e:
             success = False
 
         finally:
-            return success
+           return success

--- a/src/scrapper.py
+++ b/src/scrapper.py
@@ -56,7 +56,7 @@ class Scrapper:
 
                 for medal in matching_medals:
                     if not Medal.get_or_none(Medal.id == medal.id):
-                        success = (DBWrapper.save('Medals', medal) and success)
+                        success = (MedalFactory.medal(medal) and success)
 
         except Exception as e:
             success = False

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,9 @@
+import os
+
+os.environ = {
+            'DB_DATABASE': 'db',
+            'DB_USERNAME': 'user',
+            'DB_PASSWORD': 'pass',
+            'DB_HOST': 'host',
+            'DB_PORT': 'port'
+        }

--- a/test/fixtures/models/combat_medal_data.json
+++ b/test/fixtures/models/combat_medal_data.json
@@ -1,0 +1,20 @@
+{
+  "cost": 2,
+  "defence": 5618,
+  "direction": "Upright",
+  "element": "Speed",
+  "hits": 13,
+  "id": 862,
+  "image_link": "/static/medal_images//KH_02_Terra_and_Ventus_6.png",
+  "multiplier": "x3.40",
+  "name": "KH0.2 Terra & Ventus",
+  "notes": "Raises your power and speed attack by two steps for two turns; deals large damage",
+  "pullable": "No",
+  "rarity": 6,
+  "region": "na",
+  "strength": 5696,
+  "targets": "Single",
+  "tier": 5,
+  "type": "Combat",
+  "voice_link": "/some/random/uri/path.mp3"
+}

--- a/test/fixtures/models/combat_medal_with_ranged_multiplier_data.json
+++ b/test/fixtures/models/combat_medal_with_ranged_multiplier_data.json
@@ -1,0 +1,20 @@
+{
+  "cost": 4,
+  "defence": 5671,
+  "direction": "Reversed",
+  "element": "Speed",
+  "hits": 1,
+  "id": 944,
+  "image_link": "/static/medal_images/Final_Boss_Xion_6.png",
+  "multiplier": "x2.61-3.85",
+  "name": "Final Boss Xion",
+  "notes": "Decreases enemy defense by two steps for two turns; deals more damage the more ability gauges you have remaining",
+  "pullable": "Yes",
+  "rarity": 6,
+  "region": "na",
+  "strength": 5747,
+  "targets": "All",
+  "tier": 6,
+  "type": "Combat",
+  "voice_link": "/static/audio/JP/Final_Boss_Xion.mp3"
+}

--- a/test/fixtures/models/non_combat_medal_data.json
+++ b/test/fixtures/models/non_combat_medal_data.json
@@ -1,0 +1,20 @@
+{
+  "cost": null,
+  "defence": null,
+  "direction": null,
+  "element": null,
+  "hits": null,
+  "id": 214,
+  "image_link": "/static/medal_images/Moogle_6.png",
+  "multiplier": null,
+  "name": "Moogle",
+  "notes": "Worth 32,000 munny",
+  "pullable": "No",
+  "rarity": 6,
+  "region": "na",
+  "strength": null,
+  "targets": null,
+  "tier": null,
+  "type": "Munny",
+  "voice_link": null
+}

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -6,4 +6,4 @@ from src.models import *
 class TestModels(unittest.TestCase):
 
     def test_base_model_has_database(self):
-        self.assertIn('database', BaseModel.fields)
+        self.assertIsNotNone(BaseModel._meta.database)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -57,11 +57,7 @@ class TestFactories(unittest.TestCase):
         with open('test/fixtures/models/non_combat_medal_data.json') as fixture:
             self.non_combat_medal_json = json.loads(fixture.read())
 
-        with open('test/fixtures/models/combat_medal_data_with_ranged_multiplier.json') as fixture:
-            self.combat_medal_ranged_multiplier_json = json.loads(fixture.read())
-
         self.combat_medal = MedalFactory.medal(self.combat_medal_json)
-        self.ranged_multiplier_medal = MedalFactory.medal(self.combat_medal_ranged_multiplier_json)
 
     def test_creates_medal_if_all_fields_are_present(self):
         self.assertIsInstance(self.combat_medal, Medal)
@@ -189,7 +185,3 @@ class TestFactories(unittest.TestCase):
 
         created_medal = MedalFactory.medal(combat_medal_json_faulty)
         self.assertIsInstance(created_medal, Medal)
-
-
-
-

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,15 +1,48 @@
 import unittest
+import peewee
 
 from src.models import *
 
 
 class TestModels(unittest.TestCase):
+    "Tests for the different ORM models"
 
+    """BaseModel model"""
     def test_base_model_has_database(self):
         self.assertIsNotNone(BaseModel._meta.database)
 
     def test_base_model_has_correct_database(self):
         self.assertIsInstance(BaseModel._meta.database, PostgresqlDatabase)
 
+    """Medal model"""
     def test_medal_model_has_correct_database(self):
         self.assertIsInstance(Medal._meta.database, PostgresqlDatabase)
+
+    def test_medal_model_has_correct_fields(self):
+        expected_fields = ['cost', 'defence', 'direction', 'hits', 'id',
+                           'image_link', 'multiplier_min', 'multiplier_max',
+                           'name', 'notes', 'pullable', 'rarity', 'region',
+                           'strength', 'targets', 'tier', 'type', 'voice_link']
+        self.assertCountEqual(Medal._meta.sorted_field_names, expected_fields)
+
+    def test_medal_model_fields_have_correct_types(self):
+        fields = Medal._meta.fields
+        self.assertEqual(type(fields['cost']), peewee.IntegerField)
+        self.assertEqual(type(fields['defence']), peewee.IntegerField)
+        self.assertEqual(type(fields['direction']), peewee.CharField)
+        self.assertEqual(type(fields['hits']), peewee.IntegerField)
+        self.assertEqual(type(fields['id']), peewee.IntegerField)
+        self.assertEqual(type(fields['image_link']), peewee.TextField)
+        self.assertEqual(type(fields['multiplier_min']), peewee.FloatField)
+        self.assertEqual(type(fields['multiplier_max']), peewee.FloatField)
+        self.assertEqual(type(fields['name']), peewee.TextField)
+        self.assertEqual(type(fields['notes']), peewee.TextField)
+        self.assertEqual(type(fields['pullable']), peewee.CharField)
+        self.assertEqual(type(fields['rarity']), peewee.IntegerField)
+        self.assertEqual(type(fields['region']), peewee.CharField)
+        self.assertEqual(type(fields['strength']), peewee.IntegerField)
+        self.assertEqual(type(fields['targets']), peewee.CharField)
+        self.assertEqual(type(fields['tier']), peewee.IntegerField)
+        self.assertEqual(type(fields['type']), peewee.CharField)
+        self.assertEqual(type(fields['voice_link']), peewee.TextField)
+

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,0 +1,9 @@
+import unittest
+
+from src.models import *
+
+
+class TestModels(unittest.TestCase):
+
+    def test_base_model_has_database(self):
+        self.assertIn('database', BaseModel.fields)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,11 +1,12 @@
 import unittest
+import json
 import peewee
 
 from src.models import *
 
 
 class TestModels(unittest.TestCase):
-    "Tests for the different ORM models"
+    """Tests for the different ORM models"""
 
     """BaseModel model"""
     def test_base_model_has_database(self):
@@ -27,22 +28,168 @@ class TestModels(unittest.TestCase):
 
     def test_medal_model_fields_have_correct_types(self):
         fields = Medal._meta.fields
-        self.assertEqual(type(fields['cost']), peewee.IntegerField)
-        self.assertEqual(type(fields['defence']), peewee.IntegerField)
-        self.assertEqual(type(fields['direction']), peewee.CharField)
-        self.assertEqual(type(fields['hits']), peewee.IntegerField)
-        self.assertEqual(type(fields['id']), peewee.IntegerField)
-        self.assertEqual(type(fields['image_link']), peewee.TextField)
-        self.assertEqual(type(fields['multiplier_min']), peewee.FloatField)
-        self.assertEqual(type(fields['multiplier_max']), peewee.FloatField)
-        self.assertEqual(type(fields['name']), peewee.TextField)
-        self.assertEqual(type(fields['notes']), peewee.TextField)
-        self.assertEqual(type(fields['pullable']), peewee.CharField)
-        self.assertEqual(type(fields['rarity']), peewee.IntegerField)
-        self.assertEqual(type(fields['region']), peewee.CharField)
-        self.assertEqual(type(fields['strength']), peewee.IntegerField)
-        self.assertEqual(type(fields['targets']), peewee.CharField)
-        self.assertEqual(type(fields['tier']), peewee.IntegerField)
-        self.assertEqual(type(fields['type']), peewee.CharField)
-        self.assertEqual(type(fields['voice_link']), peewee.TextField)
+        self.assertIsInstance(fields['cost'], peewee.IntegerField)
+        self.assertIsInstance(fields['defence'], peewee.IntegerField)
+        self.assertIsInstance(fields['direction'], peewee.CharField)
+        self.assertIsInstance(fields['hits'], peewee.IntegerField)
+        self.assertIsInstance(fields['id'], peewee.IntegerField)
+        self.assertIsInstance(fields['image_link'], peewee.TextField)
+        self.assertIsInstance(fields['multiplier_min'], peewee.FloatField)
+        self.assertIsInstance(fields['multiplier_max'], peewee.FloatField)
+        self.assertIsInstance(fields['name'], peewee.TextField)
+        self.assertIsInstance(fields['notes'], peewee.TextField)
+        self.assertIsInstance(fields['pullable'], peewee.CharField)
+        self.assertIsInstance(fields['rarity'], peewee.IntegerField)
+        self.assertIsInstance(fields['region'], peewee.CharField)
+        self.assertIsInstance(fields['strength'], peewee.IntegerField)
+        self.assertIsInstance(fields['targets'], peewee.CharField)
+        self.assertIsInstance(fields['tier'], peewee.IntegerField)
+        self.assertIsInstance(fields['type'], peewee.CharField)
+        self.assertIsInstance(fields['voice_link'], peewee.TextField)
+
+
+class TestFactories(unittest.TestCase):
+
+    def setUp(self):
+        with open('test/fixtures/models/combat_medal_data.json') as fixture:
+            self.combat_medal_json = json.loads(fixture.read())
+
+        with open('test/fixtures/models/non_combat_medal_data.json') as fixture:
+            self.non_combat_medal_json = json.loads(fixture.read())
+
+        with open('test/fixtures/models/combat_medal_data_with_ranged_multiplier.json') as fixture:
+            self.combat_medal_ranged_multiplier_json = json.loads(fixture.read())
+
+        self.combat_medal = MedalFactory.medal(self.combat_medal_json)
+        self.ranged_multiplier_medal = MedalFactory.medal(self.combat_medal_ranged_multiplier_json)
+
+    def test_creates_medal_if_all_fields_are_present(self):
+        self.assertIsInstance(self.combat_medal, Medal)
+
+    def test_doesnt_create_medal_if_type_is_not_combat(self):
+        self.assertIsNone(MedalFactory.medal(self.non_combat_medal_json))
+
+    def test_sets_fields_correctly_in_medal(self):
+        self.assertEqual(self.combat_medal.id, 862)
+        self.assertEqual(self.combat_medal.cost, 2)
+        self.assertEqual(self.combat_medal.defence, 5618)
+        self.assertEqual(self.combat_medal.direction, "Upright")
+        self.assertEqual(self.combat_medal.hits, 13)
+        self.assertEqual(self.combat_medal.image_link, "/static/medal_images//KH_02_Terra_and_Ventus_6.png")
+        self.assertEqual(self.combat_medal.multiplier_min, 3.40)
+        self.assertEqual(self.combat_medal.multiplier_max, 3.40)
+        self.assertEqual(self.combat_medal.name, "KH0.2 Terra & Ventus")
+        self.assertEqual(self.combat_medal.notes, "Raises your power and speed attack by two steps for two turns; deals large damage")
+        self.assertEqual(self.combat_medal.pullable, "No")
+        self.assertEqual(self.combat_medal.rarity, 6)
+        self.assertEqual(self.combat_medal.region, "na")
+        self.assertEqual(self.combat_medal.strength, 5696)
+        self.assertEqual(self.combat_medal.targets, "Single")
+        self.assertEqual(self.combat_medal.tier, 5)
+        self.assertEqual(self.combat_medal.type, "Combat")
+        self.assertEqual(self.combat_medal.voice_link, "/some/random/uri/path.mp3")
+
+    def test_doesnt_create_medal_if_the_json_contains_an_error(self):
+        json_with_error = {"error": "Error message to use in this test"}
+        self.assertIsNone(MedalFactory.medal(json_with_error))
+
+    def test_doesnt_create_medal_if_cost_is_missing(self):
+        combat_medal_json_faulty = self.combat_medal_json
+        combat_medal_json_faulty.pop('cost')
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+        self.assertIsNone(created_medal)
+
+    def test_doesnt_create_medal_if_direction_is_missing(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty.pop('direction')
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+        self.assertIsNone(created_medal)
+
+    def test_doesnt_create_medal_if_element_is_missing(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty.pop('element')
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+        self.assertIsNone(created_medal)
+
+    def test_doesnt_create_medal_if_hits_is_missing(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty.pop('hits')
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+        self.assertIsNone(created_medal)
+
+    def test_doesnt_create_medal_if_id_is_missing(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty.pop('id')
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+        self.assertIsNone(created_medal)
+
+    def test_doesnt_create_medal_if_multiplier_is_missing(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty.pop('multiplier')
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+        self.assertIsNone(created_medal)
+
+    def test_doesnt_create_medal_if_name_is_missing(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty.pop('name')
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+        self.assertIsNone(created_medal)
+
+    def test_doesnt_create_medal_if_notes_is_missing(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty.pop('notes')
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+        self.assertIsNone(created_medal)
+
+    def test_doesnt_create_medal_if_rarity_is_missing(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty.pop('rarity')
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+        self.assertIsNone(created_medal)
+
+    def test_doesnt_create_medal_if_targets_is_missing(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty.pop('targets')
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+        self.assertIsNone(created_medal)
+
+    def test_doesnt_create_medal_if_tier_is_missing(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty.pop('tier')
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+        self.assertIsNone(created_medal)
+
+    def test_doesnt_create_medal_if_type_is_missing(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty.pop('type')
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+        self.assertIsNone(created_medal)
+
+    def test_creates_medal_if_any_other_field_is_missing(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty.pop('defence')
+        combat_medal_json_faulty.pop('image_link')
+        combat_medal_json_faulty.pop('notes')
+        combat_medal_json_faulty.pop('pullable')
+        combat_medal_json_faulty.pop('region')
+        combat_medal_json_faulty.pop('strength')
+        combat_medal_json_faulty.pop('voice_link')
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+        self.assertIsInstance(created_medal, Medal)
+
+
+
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -7,3 +7,9 @@ class TestModels(unittest.TestCase):
 
     def test_base_model_has_database(self):
         self.assertIsNotNone(BaseModel._meta.database)
+
+    def test_base_model_has_correct_database(self):
+        self.assertIsInstance(BaseModel._meta.database, PostgresqlDatabase)
+
+    def test_medal_model_has_correct_database(self):
+        self.assertIsInstance(Medal._meta.database, PostgresqlDatabase)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,7 +1,7 @@
 import unittest
 import json
 import peewee
-
+import os
 from unittest.mock import patch
 
 from src.models import *
@@ -23,6 +23,19 @@ class BaseDBTestCase(unittest.TestCase):
         test_db.create_tables(MODELS)
 
         super(BaseDBTestCase, self).setUp()
+
+    # We override the run method of the Test class to have a simpler way of mocking
+    # all the tests
+    def run(self, result=None):
+        mocked_db_credentials = {
+            'DB_DATABASE': 'db',
+            'DB_USERNAME': 'user',
+            'DB_PASSWORD': 'pass',
+            'DB_HOST': 'host',
+            'DB_PORT': 'port'
+        }
+        with patch.dict(os.environ, mocked_db_credentials):
+            super(BaseDBTestCase, self).run(result)
 
     def tearDown(self):
         # Not strictly necessary since in-memory databases only live

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -2,6 +2,8 @@ import unittest
 import json
 import peewee
 
+from unittest.mock import patch
+
 from src.models import *
 
 
@@ -20,8 +22,8 @@ class TestModels(unittest.TestCase):
         self.assertIsInstance(Medal._meta.database, PostgresqlDatabase)
 
     def test_medal_model_has_correct_fields(self):
-        expected_fields = ['cost', 'defence', 'direction', 'hits', 'id',
-                           'image_link', 'multiplier_min', 'multiplier_max',
+        expected_fields = ['cost', 'defence', 'direction', 'element', 'hits',
+                           'id', 'image_link', 'multiplier_min', 'multiplier_max',
                            'name', 'notes', 'pullable', 'rarity', 'region',
                            'strength', 'targets', 'tier', 'type', 'voice_link']
         self.assertCountEqual(Medal._meta.sorted_field_names, expected_fields)
@@ -31,6 +33,7 @@ class TestModels(unittest.TestCase):
         self.assertIsInstance(fields['cost'], peewee.IntegerField)
         self.assertIsInstance(fields['defence'], peewee.IntegerField)
         self.assertIsInstance(fields['direction'], peewee.CharField)
+        self.assertIsInstance(fields['element'], peewee.CharField)
         self.assertIsInstance(fields['hits'], peewee.IntegerField)
         self.assertIsInstance(fields['id'], peewee.IntegerField)
         self.assertIsInstance(fields['image_link'], peewee.TextField)
@@ -47,8 +50,13 @@ class TestModels(unittest.TestCase):
         self.assertIsInstance(fields['type'], peewee.CharField)
         self.assertIsInstance(fields['voice_link'], peewee.TextField)
 
+class TestMedalFactory(unittest.TestCase):
 
-class TestFactories(unittest.TestCase):
+    # We override the run method of the Test class to have a simpler way of mocking
+    # all the tests
+    def run(self, result=None):
+        with patch.object(Medal, 'save', return_value=1):
+            super(TestMedalFactory, self).run(result)
 
     def setUp(self):
         with open('test/fixtures/models/combat_medal_data.json') as fixture:
@@ -70,6 +78,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(self.combat_medal.cost, 2)
         self.assertEqual(self.combat_medal.defence, 5618)
         self.assertEqual(self.combat_medal.direction, "Upright")
+        self.assertEqual(self.combat_medal.element, "Speed")
         self.assertEqual(self.combat_medal.hits, 13)
         self.assertEqual(self.combat_medal.image_link, "/static/medal_images//KH_02_Terra_and_Ventus_6.png")
         self.assertEqual(self.combat_medal.multiplier_min, 3.40)
@@ -134,13 +143,6 @@ class TestFactories(unittest.TestCase):
     def test_doesnt_create_medal_if_name_is_missing(self):
         combat_medal_json_faulty = self.combat_medal_json.copy()
         combat_medal_json_faulty.pop('name')
-
-        created_medal = MedalFactory.medal(combat_medal_json_faulty)
-        self.assertIsNone(created_medal)
-
-    def test_doesnt_create_medal_if_notes_is_missing(self):
-        combat_medal_json_faulty = self.combat_medal_json.copy()
-        combat_medal_json_faulty.pop('notes')
 
         created_medal = MedalFactory.medal(combat_medal_json_faulty)
         self.assertIsNone(created_medal)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,12 +1,11 @@
 import unittest
 import json
 import peewee
-import os
 from unittest.mock import patch
 
-from src.models import *
+from src.models import BaseModel, Medal, MedalFactory
 
-test_db = SqliteDatabase(':memory:')
+test_db = peewee.SqliteDatabase(':memory:')
 MODELS = [BaseModel, Medal]
 
 class BaseDBTestCase(unittest.TestCase):
@@ -23,19 +22,6 @@ class BaseDBTestCase(unittest.TestCase):
         test_db.create_tables(MODELS)
 
         super(BaseDBTestCase, self).setUp()
-
-    # We override the run method of the Test class to have a simpler way of mocking
-    # all the tests
-    def run(self, result=None):
-        mocked_db_credentials = {
-            'DB_DATABASE': 'db',
-            'DB_USERNAME': 'user',
-            'DB_PASSWORD': 'pass',
-            'DB_HOST': 'host',
-            'DB_PORT': 'port'
-        }
-        with patch.dict(os.environ, mocked_db_credentials):
-            super(BaseDBTestCase, self).run(result)
 
     def tearDown(self):
         # Not strictly necessary since in-memory databases only live

--- a/test/test_scrapper.py
+++ b/test/test_scrapper.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from src.scrapper import Scrapper
 from src.db import DBWrapper
+from src.models import Medal
 
 
 class TestScrapper(unittest.TestCase):
@@ -103,32 +104,32 @@ class TestScrapper(unittest.TestCase):
         with self.requests_mock:
             self.assertCountEqual(self.scrapper.get_medal_names(), expected_names)
 
-    @patch.object(DBWrapper, 'find_all', create=True)
-    def test_missing_medals_when_there_are_missing_medals(self, mock_find_all):
+    @patch.object(Medal, 'select', create=True)
+    def test_missing_medals_when_there_are_missing_medals(self, mock_select):
         all_medals_file = 'test/fixtures/scrapper/medal_names.txt'
         with open(all_medals_file) as content:
-            medals = [name.strip() for name in content.readlines()]
-            mock_find_all.return_value = medals[:-3]
+            medals = [Medal(name=name.strip()) for name in content.readlines()]
+            mock_select.return_value = medals[:-3]
 
         expected_missing_medals = ['hd invi [ex]', 'axel b', 'illustrated halloween goofy']
         with self.requests_mock:
             missing_medals = self.scrapper.missing_medals()
 
         self.assertCountEqual(expected_missing_medals, missing_medals)
-        mock_find_all.assert_called_once_with('Medals', ['name'])
+        mock_select.assert_called_once()
 
-    @patch.object(DBWrapper, 'find_all', create=True)
-    def test_missing_medals_when_there_arent_missing_medals(self, mock_find_all):
+    @patch.object(Medal, 'select', create=True)
+    def test_missing_medals_when_there_arent_missing_medals(self, mock_select):
         all_medals_file = 'test/fixtures/scrapper/medal_names.txt'
         with open(all_medals_file) as content:
-            medals = [name.strip() for name in content.readlines()]
-            mock_find_all.return_value = medals
+            medals = [Medal(name=name.strip()) for name in content.readlines()]
+            mock_select.return_value = medals
 
         with self.requests_mock:
             missing_medals = self.scrapper.missing_medals()
 
         self.assertCountEqual(missing_medals, [])
-        mock_find_all.assert_called_once_with('Medals', ['name'])
+        mock_select.assert_called_once()
 
     @patch.object(DBWrapper, 'save', create=True)
     @patch.object(DBWrapper, 'is_present', create=True)

--- a/test/test_scrapper.py
+++ b/test/test_scrapper.py
@@ -4,7 +4,6 @@ import requests_mock
 from unittest.mock import patch
 
 from src.scrapper import Scrapper
-from src.db import DBWrapper
 from src.models import Medal, MedalFactory
 
 

--- a/test/test_scrapper.py
+++ b/test/test_scrapper.py
@@ -5,10 +5,16 @@ from unittest.mock import patch
 
 from src.scrapper import Scrapper
 from src.db import DBWrapper
-from src.models import Medal
+from src.models import Medal, MedalFactory
 
 
 class TestScrapper(unittest.TestCase):
+
+    # We override the run method of the Test class to have a simpler way of mocking
+    # all the tests
+    def run(self, result=None):
+        with patch.object(Medal, 'save', return_value=1):
+            super(TestScrapper, self).run(result)
 
     def setUp(self):
         self.scrapper = Scrapper()
@@ -58,7 +64,7 @@ class TestScrapper(unittest.TestCase):
             self.requests_mock.get(medal_with_symbol_in_name_endpoint_3, json=medal_with_symbol_in_name_response_3)
 
     def test_get_medals_when_one_medal_exists(self):
-        expected_medals = [{"cost": 7, "defence": 5645, "direction": "Upright", "element": "Power", "hits": 3,  "id": 1051, "image_link": "/static/medal_images//Illustrated_Halloween_Goofy_6.png", "multiplier": "x4.13", "name": "Illustrated Halloween Goofy", "notes": "Restores 3 guates", "pullable": "No", "rarity": 6, "region": "na", "strength": 5759, "targets": "All", "tier": 7, "type": "Combat", "voice_link": None}]
+        expected_medals = [MedalFactory.medal({"cost": 7, "defence": 5645, "direction": "Upright", "element": "Power", "hits": 3,  "id": 1051, "image_link": "/static/medal_images//Illustrated_Halloween_Goofy_6.png", "multiplier": "x4.13", "name": "Illustrated Halloween Goofy", "notes": "Restores 3 guates", "pullable": "No", "rarity": 6, "region": "na", "strength": 5759, "targets": "All", "tier": 7, "type": "Combat", "voice_link": None})]
 
         with self.requests_mock:
             medals = self.scrapper.get_medals('illustrated halloween goofy')
@@ -67,8 +73,8 @@ class TestScrapper(unittest.TestCase):
 
     def test_get_medals_when_several_medals_exist(self):
         expected_medals = [
-            {"cost": 1, "defence": 4274, "direction": "Reversed", "element": "Power", "hits": 6, "id": 986, "image_link": "/static/medal_images//Axel_B_5.png", "multiplier": "x1.72-3.20", "name": "Axel B", "notes": "Increases your power attack by three steps for one turn; deals more damage the further forward it's set in your deck", "pullable": "No", "rarity": 5, "region": "na", "strength": 4377, "targets": "Random", "tier": 3, "type": "Combat", "voice_link": None},
-            {"cost": 1, "defence": 5512, "direction": "Reversed", "element": "Power", "hits": 6, "id": 987, "image_link": "/static/medal_images//Axel_B_6.png", "multiplier": "x1.78-3.26", "name": "Axel B", "notes": "Increases your power attack by three steps for one turn; deals more damage the further forward it's set in your deck", "pullable": "No", "rarity": 6, "region": "na", "strength": 5645, "targets": "Random", "tier": 3, "type": "Combat", "voice_link": None}
+            MedalFactory.medal({"cost": 1, "defence": 4274, "direction": "Reversed", "element": "Power", "hits": 6, "id": 986, "image_link": "/static/medal_images//Axel_B_5.png", "multiplier": "x1.72-3.20", "name": "Axel B", "notes": "Increases your power attack by three steps for one turn; deals more damage the further forward it's set in your deck", "pullable": "No", "rarity": 5, "region": "na", "strength": 4377, "targets": "Random", "tier": 3, "type": "Combat", "voice_link": None}),
+            MedalFactory.medal({"cost": 1, "defence": 5512, "direction": "Reversed", "element": "Power", "hits": 6, "id": 987, "image_link": "/static/medal_images//Axel_B_6.png", "multiplier": "x1.78-3.26", "name": "Axel B", "notes": "Increases your power attack by three steps for one turn; deals more damage the further forward it's set in your deck", "pullable": "No", "rarity": 6, "region": "na", "strength": 5645, "targets": "Random", "tier": 3, "type": "Combat", "voice_link": None})
         ]
 
         with self.requests_mock:
@@ -83,9 +89,9 @@ class TestScrapper(unittest.TestCase):
         self.assertCountEqual(medals, [])
 
     def test_get_medals_when_there_are_symbols_in_query(self):
-        expected_medals_1 = [{"cost": 2, "defence": 5618, "direction": "Upright", "element": "Speed", "hits": 13, "id": 862, "image_link": "/static/medal_images//KH_02_Terra_and_Ventus_6.png", "multiplier": "x3.40", "name": "KH0.2 Terra & Ventus", "notes": "Raises your power and speed attack by two steps for two turns; deals large damage", "pullable": "No", "rarity": 6, "region": "na", "strength": 5696, "targets": "Single", "tier": 5, "type": "Combat", "voice_link": None}]
-        expected_medals_2 = [{"cost": 2, "defence": 5590, "direction": "Reversed", "element": "Speed", "hits": 5, "id": 637, "image_link": "/static/medal_images//Key_Art_3_6.png", "multiplier": "x1.38-2.72", "name": "Key Art #3", "notes": "Decreases enemy defense by one stage for the remainder of the turn; deals more damage the greater your HP", "pullable": "Yes", "rarity": 6, "region": "na", "strength": 5677, "targets": "All", "tier": 5, "type": "Combat", "voice_link": None}]
-        expected_medals_3 = [{"cost": 1, "defence": 5861, "direction": "Upright", "element": "Magic", "hits": 4, "id": 1014, "image_link": "/static/medal_images//HD_Invi_EX_6.png", "multiplier": "x3.12-4.32", "name": "HD Invi [EX]", "notes": "Increases your magic attack by seven steps, decreases enemy general defense by two steps and enemy magic defense by seven steps for two turns; deals more damage when only one enemy in the group remains or all raid parts have been destroyed; doesn't affect enemy counters", "pullable": "No", "rarity": 6, "region": "na", "strength": 6030, "targets": "All", "tier": 7, "type": "Combat", "voice_link": None}]
+        expected_medals_1 = [MedalFactory.medal({"cost": 2, "defence": 5618, "direction": "Upright", "element": "Speed", "hits": 13, "id": 862, "image_link": "/static/medal_images//KH_02_Terra_and_Ventus_6.png", "multiplier": "x3.40", "name": "KH0.2 Terra & Ventus", "notes": "Raises your power and speed attack by two steps for two turns; deals large damage", "pullable": "No", "rarity": 6, "region": "na", "strength": 5696, "targets": "Single", "tier": 5, "type": "Combat", "voice_link": None})]
+        expected_medals_2 = [MedalFactory.medal({"cost": 2, "defence": 5590, "direction": "Reversed", "element": "Speed", "hits": 5, "id": 637, "image_link": "/static/medal_images//Key_Art_3_6.png", "multiplier": "x1.38-2.72", "name": "Key Art #3", "notes": "Decreases enemy defense by one stage for the remainder of the turn; deals more damage the greater your HP", "pullable": "Yes", "rarity": 6, "region": "na", "strength": 5677, "targets": "All", "tier": 5, "type": "Combat", "voice_link": None})]
+        expected_medals_3 = [MedalFactory.medal({"cost": 1, "defence": 5861, "direction": "Upright", "element": "Magic", "hits": 4, "id": 1014, "image_link": "/static/medal_images//HD_Invi_EX_6.png", "multiplier": "x3.12-4.32", "name": "HD Invi [EX]", "notes": "Increases your magic attack by seven steps, decreases enemy general defense by two steps and enemy magic defense by seven steps for two turns; deals more damage when only one enemy in the group remains or all raid parts have been destroyed; doesn't affect enemy counters", "pullable": "No", "rarity": 6, "region": "na", "strength": 6030, "targets": "All", "tier": 7, "type": "Combat", "voice_link": None})]
 
         with self.requests_mock:
             medals_1 = self.scrapper.get_medals('KH0.2 Terra & Ventus')
@@ -132,11 +138,10 @@ class TestScrapper(unittest.TestCase):
         mock_select.assert_called_once()
 
     @patch.object(DBWrapper, 'save', create=True)
-    @patch.object(DBWrapper, 'is_present', create=True)
+    @patch.object(Medal, 'get_or_none', return_value=True)
     @patch.object(Scrapper, 'missing_medals')
-    def test_scrape_missing_medals_when_medals_are_not_in_DB(self, mock_missing_medals, mock_db_is_present, mock_db_save):
+    def test_scrape_missing_medals_when_medals_are_not_in_DB(self, mock_missing_medals, mock_get_or_none, mock_db_save):
         mock_missing_medals.return_value = ['hd invi [ex]', 'axel b', 'illustrated halloween goofy']
-        mock_db_is_present.return_value = False
         mock_db_save.return_value = True
         invi_medal = {"cost": 1, "defence": 5861, "direction": "Upright", "element": "Magic", "hits": 4, "id": 1014, "image_link": "/static/medal_images//HD_Invi_EX_6.png", "multiplier": "x3.12-4.32", "name": "HD Invi [EX]", "notes": "Increases your magic attack by seven steps, decreases enemy general defense by two steps and enemy magic defense by seven steps for two turns; deals more damage when only one enemy in the group remains or all raid parts have been destroyed; doesn't affect enemy counters", "pullable": "No", "rarity": 6, "region": "na", "strength": 6030, "targets": "All", "tier": 7, "type": "Combat", "voice_link": None}
         axel_b_5_medal = {"cost": 1, "defence": 4274, "direction": "Reversed", "element": "Power", "hits": 6, "id": 986, "image_link": "/static/medal_images//Axel_B_5.png", "multiplier": "x1.72-3.20", "name": "Axel B", "notes": "Increases your power attack by three steps for one turn; deals more damage the further forward it's set in your deck", "pullable": "No", "rarity": 5, "region": "na", "strength": 4377, "targets": "Random", "tier": 3, "type": "Combat", "voice_link": None}
@@ -147,38 +152,28 @@ class TestScrapper(unittest.TestCase):
             success = self.scrapper.scrape_missing_medals()
 
         self.assertTrue(success)
-        mock_db_is_present.assert_any_call('Medals', {"id": 1014})
-        mock_db_is_present.assert_any_call('Medals', {"id": 986})
-        mock_db_is_present.assert_any_call('Medals', {"id": 987})
-        mock_db_is_present.assert_any_call('Medals', {"id": 1051})
         mock_db_save.assert_any_call('Medals', invi_medal)
         mock_db_save.assert_any_call('Medals', axel_b_5_medal)
         mock_db_save.assert_any_call('Medals', axel_b_6_medal)
         mock_db_save.assert_any_call('Medals', ill_halloween_goofy_medal)
 
     @patch.object(DBWrapper, 'save', create=True)
-    @patch.object(DBWrapper, 'is_present', create=True)
+    @patch.object(Medal, 'get_or_none', return_value=True)
     @patch.object(Scrapper, 'missing_medals')
-    def test_scrape_missing_medals_when_medals_are_in_DB(self, mock_missing_medals, mock_db_is_present, mock_db_save):
+    def test_scrape_missing_medals_when_medals_are_in_DB(self, mock_missing_medals, mock_get_or_none, mock_db_save):
         mock_missing_medals.return_value = ['hd invi [ex]', 'axel b', 'illustrated halloween goofy']
-        mock_db_is_present.return_value = True
 
         with self.requests_mock:
             success = self.scrapper.scrape_missing_medals()
 
         self.assertTrue(success)
-        mock_db_is_present.assert_any_call('Medals', {"id": 1014})
-        mock_db_is_present.assert_any_call('Medals', {"id": 986})
-        mock_db_is_present.assert_any_call('Medals', {"id": 987})
-        mock_db_is_present.assert_any_call('Medals', {"id": 1051})
         mock_db_save.assert_not_called()
 
     @patch.object(DBWrapper, 'save', create=True)
-    @patch.object(DBWrapper, 'is_present', create=True)
+    @patch.object(Medal, 'get_or_none', return_value=False)
     @patch.object(Scrapper, 'missing_medals')
-    def test_scrape_missing_medals_when_problem_in_DB(self, mock_missing_medals, mock_db_is_present, mock_db_save):
+    def test_scrape_missing_medals_when_problem_in_DB(self, mock_missing_medals, mock_get_or_none, mock_db_save):
         mock_missing_medals.return_value = ['hd invi [ex]']
-        mock_db_is_present.return_value = False
         mock_db_save.return_value = True
         mock_db_save.side_effect = Exception('The DB couldnt save the medal')
         invi_medal = {"cost": 1, "defence": 5861, "direction": "Upright", "element": "Magic", "hits": 4, "id": 1014, "image_link": "/static/medal_images//HD_Invi_EX_6.png", "multiplier": "x3.12-4.32", "name": "HD Invi [EX]", "notes": "Increases your magic attack by seven steps, decreases enemy general defense by two steps and enemy magic defense by seven steps for two turns; deals more damage when only one enemy in the group remains or all raid parts have been destroyed; doesn't affect enemy counters", "pullable": "No", "rarity": 6, "region": "na", "strength": 6030, "targets": "All", "tier": 7, "type": "Combat", "voice_link": None}
@@ -187,5 +182,4 @@ class TestScrapper(unittest.TestCase):
             success = self.scrapper.scrape_missing_medals()
 
         self.assertFalse(success)
-        mock_db_is_present.assert_any_call('Medals', {"id": 1014})
         mock_db_save.assert_any_call('Medals', invi_medal)

--- a/test/test_scrapper.py
+++ b/test/test_scrapper.py
@@ -137,49 +137,36 @@ class TestScrapper(unittest.TestCase):
         self.assertCountEqual(missing_medals, [])
         mock_select.assert_called_once()
 
-    @patch.object(DBWrapper, 'save', create=True)
     @patch.object(Medal, 'get_or_none', return_value=True)
     @patch.object(Scrapper, 'missing_medals')
-    def test_scrape_missing_medals_when_medals_are_not_in_DB(self, mock_missing_medals, mock_get_or_none, mock_db_save):
-        mock_missing_medals.return_value = ['hd invi [ex]', 'axel b', 'illustrated halloween goofy']
-        mock_db_save.return_value = True
-        invi_medal = {"cost": 1, "defence": 5861, "direction": "Upright", "element": "Magic", "hits": 4, "id": 1014, "image_link": "/static/medal_images//HD_Invi_EX_6.png", "multiplier": "x3.12-4.32", "name": "HD Invi [EX]", "notes": "Increases your magic attack by seven steps, decreases enemy general defense by two steps and enemy magic defense by seven steps for two turns; deals more damage when only one enemy in the group remains or all raid parts have been destroyed; doesn't affect enemy counters", "pullable": "No", "rarity": 6, "region": "na", "strength": 6030, "targets": "All", "tier": 7, "type": "Combat", "voice_link": None}
-        axel_b_5_medal = {"cost": 1, "defence": 4274, "direction": "Reversed", "element": "Power", "hits": 6, "id": 986, "image_link": "/static/medal_images//Axel_B_5.png", "multiplier": "x1.72-3.20", "name": "Axel B", "notes": "Increases your power attack by three steps for one turn; deals more damage the further forward it's set in your deck", "pullable": "No", "rarity": 5, "region": "na", "strength": 4377, "targets": "Random", "tier": 3, "type": "Combat", "voice_link": None}
-        axel_b_6_medal = {"cost": 1, "defence": 5512, "direction": "Reversed", "element": "Power", "hits": 6, "id": 987, "image_link": "/static/medal_images//Axel_B_6.png", "multiplier": "x1.78-3.26", "name": "Axel B", "notes": "Increases your power attack by three steps for one turn; deals more damage the further forward it's set in your deck", "pullable": "No", "rarity": 6, "region": "na", "strength": 5645, "targets": "Random", "tier": 3, "type": "Combat", "voice_link": None}
-        ill_halloween_goofy_medal = {"cost": 7, "defence": 5645, "direction": "Upright", "element": "Power", "hits": 3, "id": 1051, "image_link": "/static/medal_images//Illustrated_Halloween_Goofy_6.png", "multiplier": "x4.13", "name": "Illustrated Halloween Goofy", "notes": "Restores 3 guates", "pullable": "No", "rarity": 6, "region": "na", "strength": 5759, "targets": "All", "tier": 7, "type": "Combat", "voice_link": None}
-        
-        with self.requests_mock:
-            success = self.scrapper.scrape_missing_medals()
-
-        self.assertTrue(success)
-        mock_db_save.assert_any_call('Medals', invi_medal)
-        mock_db_save.assert_any_call('Medals', axel_b_5_medal)
-        mock_db_save.assert_any_call('Medals', axel_b_6_medal)
-        mock_db_save.assert_any_call('Medals', ill_halloween_goofy_medal)
-
-    @patch.object(DBWrapper, 'save', create=True)
-    @patch.object(Medal, 'get_or_none', return_value=True)
-    @patch.object(Scrapper, 'missing_medals')
-    def test_scrape_missing_medals_when_medals_are_in_DB(self, mock_missing_medals, mock_get_or_none, mock_db_save):
+    def test_scrape_missing_medals_when_medals_are_not_in_DB(self, mock_missing_medals, mock_get_or_none):
         mock_missing_medals.return_value = ['hd invi [ex]', 'axel b', 'illustrated halloween goofy']
 
         with self.requests_mock:
             success = self.scrapper.scrape_missing_medals()
 
         self.assertTrue(success)
-        mock_db_save.assert_not_called()
 
-    @patch.object(DBWrapper, 'save', create=True)
+    @patch.object(Medal, 'get_or_none', return_value=True)
+    @patch.object(Scrapper, 'missing_medals')
+    def test_scrape_missing_medals_when_medals_are_in_DB(self, mock_missing_medals, mock_get_or_none):
+        mock_missing_medals.return_value = ['hd invi [ex]', 'axel b', 'illustrated halloween goofy']
+
+        with self.requests_mock:
+            success = self.scrapper.scrape_missing_medals()
+
+        self.assertTrue(success)
+
+    @patch.object(Medal, 'save', create=True)
     @patch.object(Medal, 'get_or_none', return_value=False)
     @patch.object(Scrapper, 'missing_medals')
-    def test_scrape_missing_medals_when_problem_in_DB(self, mock_missing_medals, mock_get_or_none, mock_db_save):
+    def test_scrape_missing_medals_when_problem_in_DB(self, mock_missing_medals, mock_get_or_none, mock_medal_save):
         mock_missing_medals.return_value = ['hd invi [ex]']
-        mock_db_save.return_value = True
-        mock_db_save.side_effect = Exception('The DB couldnt save the medal')
+        mock_medal_save.return_value = 1
         invi_medal = {"cost": 1, "defence": 5861, "direction": "Upright", "element": "Magic", "hits": 4, "id": 1014, "image_link": "/static/medal_images//HD_Invi_EX_6.png", "multiplier": "x3.12-4.32", "name": "HD Invi [EX]", "notes": "Increases your magic attack by seven steps, decreases enemy general defense by two steps and enemy magic defense by seven steps for two turns; deals more damage when only one enemy in the group remains or all raid parts have been destroyed; doesn't affect enemy counters", "pullable": "No", "rarity": 6, "region": "na", "strength": 6030, "targets": "All", "tier": 7, "type": "Combat", "voice_link": None}
 
         with self.requests_mock:
             success = self.scrapper.scrape_missing_medals()
 
         self.assertFalse(success)
-        mock_db_save.assert_any_call('Medals', invi_medal)
+        mock_medal_save.assert_called()


### PR DESCRIPTION
### What?
Create the classes that our ORM (currently,  `peewee`) will use to represent the objects used in the application. 

### How?
We've added two models: 
  - `Medal`: represents (obviously) a medal, and its fields correspond with the ones returned by the KHUX API. We don't use all of them (for example, `voice_link` and `image_link`), but we can add them so they are already available when we need them. 

  - `MedalFactory`: Factory class used to encapsulate the medal creation logic. It won't be stored on the database, as it doesn't represent a real object.

### Where?

- **Related PRs:** #9 

### Notes and warnings
We've also removed the stubbed "DBWrapper" logic that we were using on `Scrapper`, as we already have a way of persisting the medals

