### PR TITLE
Fixing parse_multiplier method of MedalFactory

### DIFF
--- a/khux_medal_finder/models.py
+++ b/khux_medal_finder/models.py
@@ -40,7 +40,15 @@ class MedalFactory:
 
     @classmethod
     def parse_multiplier(cls, multiplier_string):
-        return [3.40, 3.40]
+        multipliers = multiplier_string.split('-')
+        # Removing the 'x' from the string. It appears no matter if the
+        # multiplier was ranged or single, so have to do it in both cases
+        multipliers[0] = multipliers[0][1:]
+
+        if len(multipliers) > 1:
+            return [float(num) for num in multipliers]
+        else:
+            return [float(*multipliers)]*2
 
     @classmethod
     def medal(cls, medal_json):

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -85,10 +85,14 @@ class TestMedalFactory(BaseDBTestCase):
         with open('test/fixtures/models/combat_medal_data.json') as fixture:
             self.combat_medal_json = json.loads(fixture.read())
 
+        with open('test/fixtures/models/combat_medal_with_ranged_multiplier_data.json') as fixture:
+            self.combat_medal_ranged_multiplier_json = json.loads(fixture.read())
+
         with open('test/fixtures/models/non_combat_medal_data.json') as fixture:
             self.non_combat_medal_json = json.loads(fixture.read())
 
         self.combat_medal = MedalFactory.medal(self.combat_medal_json)
+        self.combat_medal_ranged_multiplier = MedalFactory.medal(self.combat_medal_ranged_multiplier_json)
 
     def test_creates_medal_if_all_fields_are_present(self):
         self.assertIsInstance(self.combat_medal, Medal)
@@ -104,8 +108,6 @@ class TestMedalFactory(BaseDBTestCase):
         self.assertEqual(self.combat_medal.element, "Speed")
         self.assertEqual(self.combat_medal.hits, 13)
         self.assertEqual(self.combat_medal.image_link, "/static/medal_images//KH_02_Terra_and_Ventus_6.png")
-        self.assertEqual(self.combat_medal.multiplier_min, 3.40)
-        self.assertEqual(self.combat_medal.multiplier_max, 3.40)
         self.assertEqual(self.combat_medal.name, "KH0.2 Terra & Ventus")
         self.assertEqual(self.combat_medal.notes, "Raises your power and speed attack by two steps for two turns; deals large damage")
         self.assertEqual(self.combat_medal.pullable, "No")
@@ -116,6 +118,14 @@ class TestMedalFactory(BaseDBTestCase):
         self.assertEqual(self.combat_medal.tier, 5)
         self.assertEqual(self.combat_medal.type, "Combat")
         self.assertEqual(self.combat_medal.voice_link, "/some/random/uri/path.mp3")
+
+    def test_parses_multiplier_correctly_if_medal_has_single_multiplier(self):
+        self.assertEqual(self.combat_medal.multiplier_min, 3.40)
+        self.assertEqual(self.combat_medal.multiplier_max, 3.40)
+
+    def test_parses_multiplier_correctly_if_medal_has_ranged_multiplier(self):
+        self.assertEqual(self.combat_medal_ranged_multiplier.multiplier_min, 2.61)
+        self.assertEqual(self.combat_medal_ranged_multiplier.multiplier_max, 3.85)
 
     def test_doesnt_create_medal_if_the_json_contains_an_error(self):
         json_with_error = {"error": "Error message to use in this test"}


### PR DESCRIPTION
We've also added tests for both the case when the medal has a single
multiplier and for when it has a ranged one.

## What?
When we created the `MedalFactory` class, we forgot to unmock the `parse_multiplier` method, and it was setting both the min and the max multiplier to 3.40. This was the multiplier of the medal used in the MedalFactory tests, so we couldn't detect it there. 

## Where?

- **Github issues:** #16 

- **Related PRs:** https://github.com/AlexGascon/KHUX-Medal-Finder/pull/11

- **Other links:** _Links to other places where this change may have been addressed or requested_

## How
We've substituted the mocked code we had for one that actually parses the multiplier string and returns both the max and the min multipliers (even removing the preceding `x` and the `-`) converted to float.

## Notes
We've also updated the test suite to include tests for both single multiplier and ranged multiplier medals,  to prevent similar things from happening again. 
