### PR TITLE
Renaming 'id' field from Medal model to 'medal_id'

### DIFF
--- a/khux_medal_finder/models.py
+++ b/khux_medal_finder/models.py
@@ -20,8 +20,8 @@ class Medal(BaseModel):
     direction = CharField()
     element = CharField()
     hits = IntegerField()
-    id = IntegerField(primary_key=True)
     image_link = TextField()
+    medal_id = IntegerField(primary_key=True)
     multiplier_min = FloatField()
     multiplier_max = FloatField()
     name = TextField()
@@ -64,7 +64,7 @@ class MedalFactory:
             created_medal.direction = medal_json['direction']
             created_medal.element = medal_json['element']
             created_medal.hits = medal_json['hits']
-            created_medal.id = medal_json['id']
+            created_medal.medal_id = medal_json['id']
             created_medal.multiplier_min, created_medal.multiplier_max = cls.parse_multiplier(medal_json['multiplier'])
             created_medal.name = medal_json['name']
             created_medal.rarity = medal_json['rarity']

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -44,7 +44,7 @@ class TestModels(BaseDBTestCase):
     """Medal model"""
     def test_medal_model_has_correct_fields(self):
         expected_fields = ['cost', 'defence', 'direction', 'element', 'hits',
-                           'id', 'image_link', 'multiplier_min', 'multiplier_max',
+                           'medal_id', 'image_link', 'multiplier_min', 'multiplier_max',
                            'name', 'notes', 'pullable', 'rarity', 'region',
                            'strength', 'targets', 'tier', 'type', 'voice_link']
         self.assertCountEqual(Medal._meta.sorted_field_names, expected_fields)
@@ -56,8 +56,8 @@ class TestModels(BaseDBTestCase):
         self.assertIsInstance(fields['direction'], peewee.CharField)
         self.assertIsInstance(fields['element'], peewee.CharField)
         self.assertIsInstance(fields['hits'], peewee.IntegerField)
-        self.assertIsInstance(fields['id'], peewee.IntegerField)
         self.assertIsInstance(fields['image_link'], peewee.TextField)
+        self.assertIsInstance(fields['medal_id'], peewee.IntegerField)
         self.assertIsInstance(fields['multiplier_min'], peewee.FloatField)
         self.assertIsInstance(fields['multiplier_max'], peewee.FloatField)
         self.assertIsInstance(fields['name'], peewee.TextField)
@@ -101,7 +101,7 @@ class TestMedalFactory(BaseDBTestCase):
         self.assertIsNone(MedalFactory.medal(self.non_combat_medal_json))
 
     def test_sets_fields_correctly_in_medal(self):
-        self.assertEqual(self.combat_medal.id, 862)
+        self.assertEqual(self.combat_medal.medal_id, 862)
         self.assertEqual(self.combat_medal.cost, 2)
         self.assertEqual(self.combat_medal.defence, 5618)
         self.assertEqual(self.combat_medal.direction, "Upright")


### PR DESCRIPTION
## What?
The Medal model has a field in which we track the `id` that the medal has in-game. This field is called `id`, which is not a good name because it's a reserved keyword in Python and we want to avoid shadowing built-in functions. 

## How
In this PR we solve that problem by changing the field name to `medal_id`, which also is more representative of the real value we're storing there. 


