### PR TITLE
Prevent multiplier parser to break execution flow if an exception is encountered

### DIFF
--- a/khux_medal_finder/exceptions.py
+++ b/khux_medal_finder/exceptions.py
@@ -1,0 +1,3 @@
+class ParseMultiplierError(ValueError):
+    """The value can't be used to obtain medal min and max multipliers"""
+    pass

--- a/khux_medal_finder/models.py
+++ b/khux_medal_finder/models.py
@@ -79,7 +79,7 @@ class MedalFactory:
             created_medal.type = medal_json['type']
 
         except (KeyError, ParseMultiplierError) as e:
-            print(f"There has been an error while trying to create the medal: {e}")
+            print(f"There has been an error while trying to create the medal: {repr(e)}")
             print(medal_json)
             return None
         

--- a/khux_medal_finder/models.py
+++ b/khux_medal_finder/models.py
@@ -1,5 +1,6 @@
 import os
 from peewee import *
+from khux_medal_finder.exceptions import ParseMultiplierError
 
 db = PostgresqlDatabase(database=os.environ['DB_DATABASE'],
                         user=os.environ['DB_USERNAME'],
@@ -41,15 +42,19 @@ class MedalFactory:
 
     @classmethod
     def parse_multiplier(cls, multiplier_string):
-        multipliers = multiplier_string.split('-')
-        # Removing the 'x' from the string. It appears no matter if the
-        # multiplier was ranged or single, so have to do it in both cases
-        multipliers[0] = multipliers[0][1:]
+        try:
+            multipliers = multiplier_string.split('-')
 
-        if len(multipliers) > 1:
-            return [float(num) for num in multipliers]
-        else:
-            return [float(*multipliers)]*2
+            if multipliers[0].startswith('x'):
+                multipliers[0] = multipliers[0][1:]
+
+            if len(multipliers) == 1:
+                multipliers = [multipliers[0]] * 2
+
+            return list(map(float, multipliers))
+
+        except Exception:
+            raise ParseMultiplierError(f"The value {multiplier_string} couldn't be parsed")
 
     @classmethod
     def medal(cls, medal_json):

--- a/khux_medal_finder/models.py
+++ b/khux_medal_finder/models.py
@@ -78,7 +78,9 @@ class MedalFactory:
             created_medal.tier = medal_json['tier']
             created_medal.type = medal_json['type']
 
-        except KeyError:
+        except (KeyError, ParseMultiplierError) as e:
+            print(f"There has been an error while trying to create the medal: {e}")
+            print(medal_json)
             return None
         
         created_medal.defence = medal_json.get('defence', None)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -127,6 +127,31 @@ class TestMedalFactory(BaseDBTestCase):
         self.assertEqual(self.combat_medal_ranged_multiplier.multiplier_min, 2.61)
         self.assertEqual(self.combat_medal_ranged_multiplier.multiplier_max, 3.85)
 
+    def test_parses_multiplier_correctly_if_doesnt_start_with_x(self):
+        combat_medal_json_without_x = self.combat_medal_json.copy()
+        combat_medal_json_without_x['multiplier'] = "3.29-7.12"
+
+        created_medal = MedalFactory.medal(combat_medal_json_without_x)
+
+        self.assertEqual(created_medal.multiplier_min, 3.29)
+        self.assertEqual(created_medal.multiplier_max, 7.12)
+
+    def test_medal_is_not_created_if_multiplier_is_None(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty['multiplier'] = None
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+
+        self.assertIsNone(created_medal)
+
+    def test_medal_is_not_created_if_multiplier_doesnt_have_correct_separator(self):
+        combat_medal_json_faulty = self.combat_medal_json.copy()
+        combat_medal_json_faulty['multiplier'] = "x3.29~7.12"
+
+        created_medal = MedalFactory.medal(combat_medal_json_faulty)
+
+        self.assertIsNone(created_medal)
+
     def test_doesnt_create_medal_if_the_json_contains_an_error(self):
         json_with_error = {"error": "Error message to use in this test"}
         self.assertIsNone(MedalFactory.medal(json_with_error))


### PR DESCRIPTION
## What?
If an exception appeared during the parsing of the medal's multiplier, it was raised breaking the app execution flow. With these changes, we will expect parsing errors, and limit their scope to only the specific medal that has caused that error.

## How
We've created a specific exception type, `ParseMultiplierError`, and wrapped with it the whole `parse_multiplier` method. In case any `Exception` appears during the processing, we will raise `ParseMultiplierError` instead to let other methods have a better understanding of the situation.

For example, we've added it to the list of exceptions we catch on `MedalFactory.medal`, so we will stop that medal's creation but the error won't propagate any further. 

## Where?

- **Github issues:** Fixes #26 

## Notes and warnings
We've added a few more tests to MedalFactory to check that the medal is in fact not created but it doesn't raise any exception.