### PR TITLE
Accept curved separator in multiplier

### DIFF
--- a/khux_medal_finder/helpers.py
+++ b/khux_medal_finder/helpers.py
@@ -25,3 +25,14 @@ def prepare_multiplier(medal):
         return f'x{medal.multiplier_max}'
     else:
         return f'x{medal.multiplier_min} - {medal.multiplier_max}'
+
+def prepare_multiplier_string(input_multiplier_string):
+    processed_multiplier_string = input_multiplier_string.strip()
+
+    if processed_multiplier_string.lower().startswith('x'):
+        processed_multiplier_string = processed_multiplier_string[1:]
+
+    if '~' in processed_multiplier_string:
+        processed_multiplier_string = processed_multiplier_string.replace('~', '-')
+
+    return processed_multiplier_string

--- a/khux_medal_finder/models.py
+++ b/khux_medal_finder/models.py
@@ -1,5 +1,7 @@
 import os
 from peewee import *
+
+from khux_medal_finder import helpers
 from khux_medal_finder.exceptions import ParseMultiplierError
 
 db = PostgresqlDatabase(database=os.environ['DB_DATABASE'],
@@ -43,10 +45,8 @@ class MedalFactory:
     @classmethod
     def parse_multiplier(cls, multiplier_string):
         try:
-            multipliers = multiplier_string.split('-')
-
-            if multipliers[0].startswith('x'):
-                multipliers[0] = multipliers[0][1:]
+            processed_multiplier_string = helpers.prepare_multiplier_string(multiplier_string)
+            multipliers = processed_multiplier_string.split('-')
 
             if len(multipliers) == 1:
                 multipliers = [multipliers[0]] * 2

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -3,7 +3,7 @@ import unittest
 import peewee
 
 from khux_medal_finder.models import MedalFactory, Medal
-from khux_medal_finder.helpers import prepare_reply_body
+from khux_medal_finder.helpers import prepare_reply_body, prepare_multiplier_string
 
 test_db = peewee.SqliteDatabase(':memory:')
 class TestPrepareReplyBody(unittest.TestCase):
@@ -66,3 +66,29 @@ class TestPrepareReplyBody(unittest.TestCase):
 
         self.assertEqual(obtained_table, expected_table)
 
+
+class TestPrepareMultiplierString(unittest.TestCase):
+
+    def test_returns_correct_result_if_the_string_is_already_valid(self):
+        input_string = '3.97-7.12'
+        self.assertEqual(input_string, prepare_multiplier_string(input_string))
+
+    def test_returns_correct_result_if_the_string_has_leading_and_trailing_whitespaces(self):
+        input_string = '       3.97-7.12      '
+        self.assertEqual('3.97-7.12', prepare_multiplier_string(input_string))
+
+    def test_returns_correct_result_if_the_string_has_curved_separator(self):
+        input_string = '3.97~7.12'
+        self.assertEqual('3.97-7.12', prepare_multiplier_string(input_string))
+
+    def test_returns_correct_result_if_the_string_starts_with_x(self):
+        input_string = 'x3.97-7.12'
+        self.assertEqual('3.97-7.12', prepare_multiplier_string(input_string))
+
+    def test_returns_correct_result_when_there_are_whitespaces_x_and_curved_separator(self):
+        input_string = '    x3.97~7.12          '
+        self.assertEqual('3.97-7.12', prepare_multiplier_string(input_string))
+
+    def test_raises_an_exception_if_string_is_none(self):
+        with self.assertRaises(Exception):
+            prepare_multiplier_string(None)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -136,6 +136,16 @@ class TestMedalFactory(BaseDBTestCase):
         self.assertEqual(created_medal.multiplier_min, 3.29)
         self.assertEqual(created_medal.multiplier_max, 7.12)
 
+    def test_medal_is_created_correctly_if_multiplier_has_curved_separator(self):
+
+        combat_medal_json_curved = self.combat_medal_json.copy()
+        combat_medal_json_curved['multiplier'] = "x3.29~7.12"
+
+        created_medal = MedalFactory.medal(combat_medal_json_curved)
+
+        self.assertEqual(created_medal.multiplier_min, 3.29)
+        self.assertEqual(created_medal.multiplier_max, 7.12)
+
     def test_medal_is_not_created_if_multiplier_is_None(self):
         combat_medal_json_faulty = self.combat_medal_json.copy()
         combat_medal_json_faulty['multiplier'] = None

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -144,14 +144,6 @@ class TestMedalFactory(BaseDBTestCase):
 
         self.assertIsNone(created_medal)
 
-    def test_medal_is_not_created_if_multiplier_doesnt_have_correct_separator(self):
-        combat_medal_json_faulty = self.combat_medal_json.copy()
-        combat_medal_json_faulty['multiplier'] = "x3.29~7.12"
-
-        created_medal = MedalFactory.medal(combat_medal_json_faulty)
-
-        self.assertIsNone(created_medal)
-
     def test_doesnt_create_medal_if_the_json_contains_an_error(self):
         json_with_error = {"error": "Error message to use in this test"}
         self.assertIsNone(MedalFactory.medal(json_with_error))


### PR DESCRIPTION
## What?
We were having some problems when parsing medals because the API data for some of them used a curved separator for the multiplier (`~`) instead of the usual separator `-`. As this was supposed to be a rare problem, we simply made changes to prevent it from breaking the full execution flow (#26). 

However, we've been encountering more and more occurrences and always on new medals, so it's possible that all the medals from a certain point use the curved separator instead of the usual one. This makes not acceptable to simply ignore those medals and expect the creator to fix the data, because there will be a lot of medals whose values we won't have. 

Therefore, with this PR we introduce changes to make also possible to parse medals when the curved multiplier is the used one. 

## How
We have created a new helper method, `prepare_multiplier_string`, that cleans the input string before it is used by the rest of the methods. The operations done are: 

1. Remove leading and trailing whitespaces
2. Removing the leading `x` of the string*
3. Replacing any occurrence of `~` by `-`

* This operation was already being applied before parsing the multiplier, but now we've moved it to this method. 

We've also changed an old test that checked that no medal was created where the multiplier was `~`. As we've now changed the behaviour, this test was no longer applicable as it was.

## Where?
- **Related PRs:** https://github.com/AlexGascon/KHUX-Medal-Finder/issues/26


