### PR TITLE
Make MedalFactory not return non-persisted medals

### DIFF
--- a/khux_medal_finder/api.py
+++ b/khux_medal_finder/api.py
@@ -1,7 +1,9 @@
 import requests
 from urllib.parse import urlencode
 
-from khux_medal_finder.models import Medal, MedalFactory
+from khux_medal_finder.models import Medal
+from khux_medal_finder.factories import MedalFactory
+
 
 class Search:
 

--- a/khux_medal_finder/api.py
+++ b/khux_medal_finder/api.py
@@ -90,8 +90,13 @@ class Scrapper:
 
         for medal_name in missing_medals_names:
             matching_medals = self.get_medals(medal_name)
+            print(f"Current medal: {medal_name}")
 
             for medal in matching_medals:
                 if not Medal.get_or_none(Medal.medal_id == medal['id']):
-                    print(f"Creating medal {medal['name']} - {medal['rarity']}")
-                    MedalFactory.medal(medal)
+                    created_medal = MedalFactory.medal(medal)
+
+                    if created_medal:
+                        print(f"{created_medal['name']} - {created_medal['rarity']}* was correctly created")
+                    else:
+                        print(f"Couldn't create medal {medal['name']} - {medal['rarity']}*")

--- a/khux_medal_finder/api.py
+++ b/khux_medal_finder/api.py
@@ -97,6 +97,6 @@ class Scrapper:
                     created_medal = MedalFactory.medal(medal)
 
                     if created_medal:
-                        print(f"{created_medal['name']} - {created_medal['rarity']}* was correctly created")
+                        print(f"{created_medal.name} - {created_medal.rarity}* was correctly created")
                     else:
                         print(f"Couldn't create medal {medal['name']} - {medal['rarity']}*")

--- a/khux_medal_finder/factories.py
+++ b/khux_medal_finder/factories.py
@@ -1,0 +1,59 @@
+from khux_medal_finder import helpers
+from khux_medal_finder.exceptions import ParseMultiplierError
+from khux_medal_finder.models import Medal
+
+
+class MedalFactory:
+
+    @classmethod
+    def parse_multiplier(cls, multiplier_string):
+        try:
+            processed_multiplier_string = helpers.prepare_multiplier_string(multiplier_string)
+            multipliers = processed_multiplier_string.split('-')
+
+            if len(multipliers) == 1:
+                multipliers = [multipliers[0]] * 2
+
+            return list(map(float, multipliers))
+
+        except Exception:
+            raise ParseMultiplierError(f"The value {multiplier_string} couldn't be parsed")
+
+    @classmethod
+    def medal(cls, medal_json):
+        created_medal = Medal()
+
+        # We only care about combat medals
+        if not medal_json.get('type', None) == 'Combat':
+            return None
+
+        # Setting the required attributes. If any is empty, we won't create the medal
+        try:
+            created_medal.cost = medal_json['cost']
+            created_medal.direction = medal_json['direction']
+            created_medal.element = medal_json['element']
+            created_medal.hits = medal_json['hits']
+            created_medal.medal_id = medal_json['id']
+            created_medal.multiplier_min, created_medal.multiplier_max = cls.parse_multiplier(medal_json['multiplier'])
+            created_medal.name = medal_json['name']
+            created_medal.rarity = medal_json['rarity']
+            created_medal.targets = medal_json['targets']
+            created_medal.tier = medal_json['tier']
+            created_medal.type = medal_json['type']
+
+        except (KeyError, ParseMultiplierError) as e:
+            print(f"There has been an error while trying to create the medal: {repr(e)}")
+            print(medal_json)
+            return None
+
+        created_medal.defence = medal_json.get('defence', None)
+        created_medal.image_link = medal_json.get('image_link', None)
+        created_medal.notes = medal_json.get('notes', None)
+        created_medal.pullable = medal_json.get('pullable', None)
+        created_medal.rarity = medal_json.get('rarity', None)
+        created_medal.region = medal_json.get('region', None)
+        created_medal.strength = medal_json.get('strength', None)
+        created_medal.voice_link = medal_json.get('voice_link', None)
+
+        if created_medal.save(force_insert=True):
+            return created_medal

--- a/khux_medal_finder/models.py
+++ b/khux_medal_finder/models.py
@@ -1,9 +1,6 @@
 import os
 from peewee import *
 
-from khux_medal_finder import helpers
-from khux_medal_finder.exceptions import ParseMultiplierError
-
 db = PostgresqlDatabase(database=os.environ['DB_DATABASE'],
                         user=os.environ['DB_USERNAME'],
                         password=os.environ['DB_PASSWORD'],
@@ -38,63 +35,6 @@ class Medal(BaseModel):
     tier = IntegerField()
     type = CharField(max_length=10)
     voice_link = TextField(null=True)
-
-
-class MedalFactory:
-
-    @classmethod
-    def parse_multiplier(cls, multiplier_string):
-        try:
-            processed_multiplier_string = helpers.prepare_multiplier_string(multiplier_string)
-            multipliers = processed_multiplier_string.split('-')
-
-            if len(multipliers) == 1:
-                multipliers = [multipliers[0]] * 2
-
-            return list(map(float, multipliers))
-
-        except Exception:
-            raise ParseMultiplierError(f"The value {multiplier_string} couldn't be parsed")
-
-    @classmethod
-    def medal(cls, medal_json):
-        created_medal = Medal()
-
-        # We only care about combat medals
-        if not medal_json.get('type', None) == 'Combat':
-            return None
-
-        # Setting the required attributes. If any is empty, we won't create the medal
-        try:
-            created_medal.cost = medal_json['cost']
-            created_medal.direction = medal_json['direction']
-            created_medal.element = medal_json['element']
-            created_medal.hits = medal_json['hits']
-            created_medal.medal_id = medal_json['id']
-            created_medal.multiplier_min, created_medal.multiplier_max = cls.parse_multiplier(medal_json['multiplier'])
-            created_medal.name = medal_json['name']
-            created_medal.rarity = medal_json['rarity']
-            created_medal.targets = medal_json['targets']
-            created_medal.tier = medal_json['tier']
-            created_medal.type = medal_json['type']
-
-        except (KeyError, ParseMultiplierError) as e:
-            print(f"There has been an error while trying to create the medal: {repr(e)}")
-            print(medal_json)
-            return None
-        
-        created_medal.defence = medal_json.get('defence', None)
-        created_medal.image_link = medal_json.get('image_link', None)
-        created_medal.notes = medal_json.get('notes', None)
-        created_medal.pullable = medal_json.get('pullable', None)
-        created_medal.rarity = medal_json.get('rarity', None)
-        created_medal.region = medal_json.get('region', None)
-        created_medal.strength = medal_json.get('strength', None)
-        created_medal.voice_link = medal_json.get('voice_link', None)
-
-        created_medal.save(force_insert=True)
-
-        return created_medal
 
 
 class Comment(BaseModel):

--- a/test/test_api_scrapper.py
+++ b/test/test_api_scrapper.py
@@ -4,7 +4,8 @@ import requests_mock
 from unittest.mock import patch
 
 from khux_medal_finder.api import Scrapper
-from khux_medal_finder.models import Medal, MedalFactory
+from khux_medal_finder.models import Medal
+from khux_medal_finder.factories import MedalFactory
 
 
 class TestScrapper(unittest.TestCase):

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -2,7 +2,8 @@ import json
 import unittest
 import peewee
 
-from khux_medal_finder.models import MedalFactory, Medal
+from khux_medal_finder.models import Medal
+from khux_medal_finder.factories import MedalFactory
 from khux_medal_finder.helpers import prepare_reply_body, prepare_multiplier_string
 
 test_db = peewee.SqliteDatabase(':memory:')

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -3,7 +3,8 @@ import json
 import peewee
 from unittest.mock import patch
 
-from khux_medal_finder.models import BaseModel, Medal, MedalFactory
+from khux_medal_finder.models import BaseModel, Medal
+from khux_medal_finder.factories import MedalFactory
 
 test_db = peewee.SqliteDatabase(':memory:')
 MODELS = [BaseModel, Medal]


### PR DESCRIPTION
## What?
The main method of `MedalFactory`, `medal`, ends by returning the created medal. In case we encounter any problem during the creation, like trying to create a non-combat medal or trying to create a medal when a required parameter is missing, we return `None` instead to indicate that it wasn't possible to create the medal. However, if there is a problem during the `save` operation and it doesn't raise an Exception, the medal will also be returned despite it hasn't been persisted to the DB. This can create a lot of confusion because we expect `None` to be returned if the medal hasn't actually been created (like in this case). 

As we don't want this to happen, with this PR we modify the code of `MedalFactory.medal` to return the medal only if it has been correctly persisted to the DB.

## How
To know for sure if the Medal has been persisted, we use the return value of the `save` method. This method returns an integer representing the number of rows modified (as we can see [in its docs](http://docs.peewee-orm.com/en/latest/peewee/api.html#Model.save)).

Therefore, if the object hasn't been saved to the DB (i.e. the number of modified rows is 0), we won't execute the return statement and the method will with `None` instead. But if the object has been inserted, at least one row will have been modified and therefore we will enter the `if` conditional.


We have also made an additional change: we've moved the `MedalFactory` class out of the `models.py` file and set it in `factories.py`, as it is not an actual Database model and therefore it didn't make sense to have it there.

