### PR TITLE
Ignore letter case when finding missing medals

### DIFF
--- a/khux_medal_finder/api.py
+++ b/khux_medal_finder/api.py
@@ -78,7 +78,7 @@ class Scrapper:
 
     def missing_medals(self):
         """Gets the names of all the medals that aren't yet on the DB"""
-        current_medals = set(medal.name for medal in Medal.select())
+        current_medals = set(medal.name.lower() for medal in Medal.select())
         total_medals = set(self.get_medal_names())
 
         return list(total_medals - current_medals)


### PR DESCRIPTION
## What?
Despite we've been introducing a lot of medals in the DB, these medals keep appearing on the result returned by the `missing_medals` method.

After deep observation, this is happening because the `get_medal_names` method returns all the names in lowercase, while the actual API data is written normally. Therefore, if we compare the names, they won't match. This is not the expected behaviour, and we want to fix it.

## How
When grabbing the names of all the medals in our DB, we will convert them to lowercase before comparing them with the names returned by the API.
