### PR TITLE
Improve DB settings in tests

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,0 +1,31 @@
+import unittest
+import peewee
+from khux_medal_finder.models import BaseModel, Medal
+
+test_db = peewee.SqliteDatabase(':memory:')
+MODELS = [BaseModel, Medal]
+
+class BaseDBTestCase(unittest.TestCase):
+    """TestCase class to use in the test cases where we need to query a DB.
+    It uses a temporary DB to avoid messing with our production one"""
+    def run(self, result=None):
+       with test_db.bind_ctx(MODELS):
+           super(BaseDBTestCase, self).run(result)
+
+    def setUp(self):
+        test_db.connect()
+        test_db.create_tables(MODELS)
+
+        super(BaseDBTestCase, self).setUp()
+
+    def tearDown(self):
+        # Not strictly necessary since in-memory databases only live
+        # for the duration of the connection, and in the next step we close
+        # the connection...but a good practice all the same.
+        test_db.drop_tables(MODELS)
+
+        # Close connection to db.
+        test_db.close()
+
+        super(BaseDBTestCase, self).tearDown()
+

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,9 +1,9 @@
 import unittest
 import peewee
-from khux_medal_finder.models import BaseModel, Medal
+from khux_medal_finder.models import BaseModel, Medal, Comment, Reply
 
 test_db = peewee.SqliteDatabase(':memory:')
-MODELS = [BaseModel, Medal]
+MODELS = [BaseModel, Medal, Comment, Reply]
 
 class BaseDBTestCase(unittest.TestCase):
     """TestCase class to use in the test cases where we need to query a DB.

--- a/test/test_api_scrapper.py
+++ b/test/test_api_scrapper.py
@@ -9,13 +9,6 @@ from khux_medal_finder.factories import MedalFactory
 
 from test.helpers import BaseDBTestCase
 
-class TestScrapper(unittest.TestCase):
-
-    # We override the run method of the Test class to have a simpler way of mocking
-    # all the tests
-    def run(self, result=None):
-        with patch.object(Medal, 'save', return_value=1):
-            super(TestScrapper, self).run(result)
 class TestScrapper(BaseDBTestCase):
 
     def setUp(self):

--- a/test/test_api_scrapper.py
+++ b/test/test_api_scrapper.py
@@ -134,6 +134,19 @@ class TestScrapper(BaseDBTestCase):
         self.assertCountEqual(missing_medals, [])
         mock_select.assert_called_once()
 
+    @patch.object(Scrapper, 'get_medal_names')
+    def test_missing_medals_stop_being_missing_when_we_create_them(self, mock_get_medal_names):
+        medal_names = ['hd invi [ex]', 'axel b', 'illustrated halloween goofy']
+        mock_get_medal_names.return_value = medal_names
+
+        number_of_missing_medals = len(self.scrapper.missing_medals())
+        invi_data_filename = 'test/fixtures/scrapper/medal_with_symbol_in_name_3.json'
+        with open(invi_data_filename) as invi_data_file:
+            invi_data = json.loads(invi_data_file.read())['medal']['0']
+            MedalFactory.medal(invi_data)
+
+        self.assertEqual(len(self.scrapper.missing_medals()), number_of_missing_medals - 1)
+
     @patch.object(Medal, 'get_or_none', return_value=None)
     @patch.object(Scrapper, 'missing_medals')
     def test_scrape_missing_medals_when_medals_are_not_in_DB(self, mock_missing_medals, mock_get_or_none):

--- a/test/test_api_scrapper.py
+++ b/test/test_api_scrapper.py
@@ -171,3 +171,15 @@ class TestScrapper(BaseDBTestCase):
                 self.scrapper.scrape_missing_medals()
 
             mocked_medalfactory.assert_not_called()
+
+    @patch.object(Scrapper, 'missing_medals')
+    def test_scrape_missing_medals_doesnt_stop_if_a_medal_cant_be_created(self, mock_missing_medals):
+        mock_missing_medals.return_value = ['hd invi [ex]', 'axel b', 'illustrated halloween goofy']
+
+        with patch.object(MedalFactory, 'medal') as mocked_medalfactory:
+            with self.requests_mock:
+                self.scrapper.scrape_missing_medals()
+
+            # Despite there are only 3 medals in missing_medals, the method is
+            # called 4 times because Axel B has two versions: 5 and 6 stars.
+            self.assertEqual(mocked_medalfactory.call_count, 4)

--- a/test/test_api_scrapper.py
+++ b/test/test_api_scrapper.py
@@ -177,6 +177,8 @@ class TestScrapper(BaseDBTestCase):
         mock_missing_medals.return_value = ['hd invi [ex]', 'axel b', 'illustrated halloween goofy']
 
         with patch.object(MedalFactory, 'medal') as mocked_medalfactory:
+            mocked_medalfactory.return_value = None
+
             with self.requests_mock:
                 self.scrapper.scrape_missing_medals()
 

--- a/test/test_api_scrapper.py
+++ b/test/test_api_scrapper.py
@@ -7,6 +7,7 @@ from khux_medal_finder.api import Scrapper
 from khux_medal_finder.models import Medal
 from khux_medal_finder.factories import MedalFactory
 
+from test.helpers import BaseDBTestCase
 
 class TestScrapper(unittest.TestCase):
 
@@ -15,6 +16,7 @@ class TestScrapper(unittest.TestCase):
     def run(self, result=None):
         with patch.object(Medal, 'save', return_value=1):
             super(TestScrapper, self).run(result)
+class TestScrapper(BaseDBTestCase):
 
     def setUp(self):
         self.scrapper = Scrapper()
@@ -62,6 +64,8 @@ class TestScrapper(unittest.TestCase):
             with open(medal_with_symbol_in_name_fixture_file_3) as medal_with_symbol_in_name_fixture_3:
                 medal_with_symbol_in_name_response_3 = json.loads(medal_with_symbol_in_name_fixture_3.read())
             self.requests_mock.get(medal_with_symbol_in_name_endpoint_3, json=medal_with_symbol_in_name_response_3)
+
+        super(TestScrapper, self).setUp()
 
     def test_get_medals_when_one_medal_exists(self):
         expected_medals = [{"cost": 7, "defence": 5645, "direction": "Upright", "element": "Power", "hits": 3,  "id": 1051, "image_link": "/static/medal_images//Illustrated_Halloween_Goofy_6.png", "multiplier": "x4.13", "name": "Illustrated Halloween Goofy", "notes": "Restores 3 guates", "pullable": "No", "rarity": 6, "region": "na", "strength": 5759, "targets": "All", "tier": 7, "type": "Combat", "voice_link": None}]

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,39 +1,11 @@
-import unittest
 import json
 import peewee
 from unittest.mock import patch
 
-from khux_medal_finder.models import BaseModel, Medal
 from khux_medal_finder.factories import MedalFactory
+from khux_medal_finder.models import BaseModel, Medal
 
-test_db = peewee.SqliteDatabase(':memory:')
-MODELS = [BaseModel, Medal]
-
-class BaseDBTestCase(unittest.TestCase):
-    """TestCase class to use in the test cases where we need to query a DB.
-    It uses a temporary DB to avoid messing with our production one"""
-
-    def setUp(self):
-
-        # Bind model classes to test db
-        for model in MODELS:
-            model.bind(test_db, bind_refs=False, bind_backrefs=False)
-
-        test_db.connect()
-        test_db.create_tables(MODELS)
-
-        super(BaseDBTestCase, self).setUp()
-
-    def tearDown(self):
-        # Not strictly necessary since in-memory databases only live
-        # for the duration of the connection, and in the next step we close
-        # the connection...but a good practice all the same.
-        test_db.drop_tables(MODELS)
-
-        # Close connection to db.
-        test_db.close()
-
-        super(BaseDBTestCase, self).tearDown()
+from test.helpers import BaseDBTestCase
 
 class TestModels(BaseDBTestCase):
     """Tests for the different ORM models"""

--- a/test/test_reddit_reddit_service.py
+++ b/test/test_reddit_reddit_service.py
@@ -10,6 +10,8 @@ from khux_medal_finder import helpers
 from khux_medal_finder.models import Comment, Reply
 from khux_medal_finder.reddit import RedditService
 
+from test.helpers import BaseDBTestCase
+
 ENV_MOCK = {
     'REDDIT_BOT_TOKEN': "fake token",
     'REDDIT_BOT_SECRET': "fake bot secret",
@@ -88,7 +90,7 @@ class TestRedditServiceInitialization(unittest.TestCase):
         self.env_patcher.stop()
 
 
-class TestRedditService(unittest.TestCase):
+class TestRedditService(BaseDBTestCase):
 
 
     def setUp(self):


### PR DESCRIPTION
## What?
The DB settings for our testing environment weren't as perfect as we would like them to be: we were directly binding the models to the test DB, but this created problems because sometimes they get unbound during the test execution (and bound to their default DB instead). Also, the testing class with a custom DB was coded directly in the `test_models.py` file, which made it difficult to reuse on other test classes. 

We want to be able to use the testing DB without needing to repeat a lot of overhead and configuration, and also to be completely sure that our tests won't mess up with our production DB.  

## How
The changes introduced in this PR affect several areas:

**Major changes**
1) Extracted `BaseDBTestCase` to a separate file, `test\helpers.py`. This will simplify its importing, making it easier to use from any class of our test suite. 
2) Changed how we bind our models to the testing DB: instead of binding them on `setUp` and unbinding on `tearDown`, we've overridden the `run` method to make it execute within the `bind_ctx` context manager. This makes us be sure that the models will be bound to the test DB only during the test execution (and also, that they will be bound during all the test execution, preventing leaks to our prod DB)

**Minor changes**
1) Modified `TestScrapper` class so it also inherits from `BaseDBTestCase`. This will let us stop mocking the medal creations during the executions of `MedalFactory.medal`, and therefore resulting in an execution closer than what we'll get in the reality. 
2) Fixed a bug in `TestScrapper.setUp` method that made it not call the `setUp` method of its parent class.
3) Added two new tests to complement the existing suite: one that checks that tries to create all the missing medals even if the creation of any of them has failed and one that checks that a medal stops being considered missing after we create it. The former of this tests wasn't added when the corresponding code was added (#30), and the latter test has only been possible after the other changes introduced in this PR. 

## Where?
- **Related PRs:** #31